### PR TITLE
v6.1.1 - Fix `dcli_core: 7.2.0` compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 6.1.1
+
+- Fix issue with `dcli_core: 7.2.0`.
+
+- dcli: ^7.2.0
+- dcli_core: ^7.2.0
+- dcli_input: ^7.2.0
+- dcli_terminal: ^7.2.0
+- watcher: ^1.1.4
+
 # 6.1.0
 - improvements to the onepub pub private command with respect to the messages we output. Better handling of the 'none' publish_to value and fixed the url to the publish doco.
 - updated the publish url to the actual documentation on publishing a package.

--- a/lib/src/my_runner.dart
+++ b/lib/src/my_runner.dart
@@ -39,7 +39,7 @@ class MyRunner extends CommandRunner<int> {
 
     results = argParser.parse(args);
 
-    await Settings().setVerbose(enabled: results['debug'] as bool);
+    Settings().setVerbose(enabled: results['debug'] as bool);
 
     final version = results['version'] as bool;
     if (version) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -229,42 +229,42 @@ packages:
     dependency: "direct dev"
     description:
       name: dcli
-      sha256: cdcff71ddccbe43b1ff978d064ab4568ba8b1203b49c27f70dedb88f802ce61c
+      sha256: "35fcf7cf3462c4782cb33f5f112d384affac75db40b6e9f53e06081486302f3b"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   dcli_common:
     dependency: transitive
     description:
       name: dcli_common
-      sha256: c23102596ad1cfbb29d19afb1f73deb39cbd575c90e1a1da2a3b76f6c2289254
+      sha256: be0e31188b15752be862ca40d29b5f68c7bad0806cf52b5de4ca9c0b6e87f98f
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   dcli_core:
     dependency: "direct main"
     description:
       name: dcli_core
-      sha256: "5da8cbe866604df30cfe5082ba3753cb4b5f1e3139f36614bbeb388391fed398"
+      sha256: b209513926c8c7eb6f409cf2131326649299d29a8725761c27fa5253e3f9e355
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   dcli_input:
     dependency: "direct main"
     description:
       name: dcli_input
-      sha256: b4b7b7a931746b08b0a225dcb2b964d6da80561ccd07b301e25c9cfd573a4b0f
+      sha256: "0c56a0dbc98ac67e185943757adf8d454ed0160e31a7476aeadf14953d353ec4"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   dcli_terminal:
     dependency: "direct main"
     description:
       name: dcli_terminal
-      sha256: "677bd88487fc6a61d720ce59aaeac90bd69790220f1879073cfb1300f51f8aac"
+      sha256: fa6e504035553b5bf87305d1d15bb6d1467ee63efd44240529dccca0ffccefe8
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   equatable:
     dependency: "direct main"
     description:
@@ -845,10 +845,10 @@ packages:
     dependency: "direct main"
     description:
       name: watcher
-      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   web:
     dependency: transitive
     description:
@@ -885,10 +885,10 @@ packages:
     dependency: "direct main"
     description:
       name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.15.0"
   yaml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: onepub
-version: 6.1.0
+version: 6.1.1
 homepage: https://onepub.dev
 documentation: https://docs.onepub.dev
 description: Command line tools for the OnePub private Dart/Flutter repository.
@@ -26,9 +26,9 @@ dependencies:
   crypto: ^3.0.6
   csv: ^6.0.0
   dart_console: ^4.1.0
-  dcli_core: ^7.0.3
-  dcli_input: ^7.0.2
-  dcli_terminal: ^7.0.3
+  dcli_core: ^7.2.0
+  dcli_input: ^7.2.0
+  dcli_terminal: ^7.2.0
   equatable: ^2.0.7
   ffi: ^2.1.2
   file: ^7.0.1
@@ -81,14 +81,14 @@ dependencies:
   usage: 4.1.1
   uuid: ^4.4.0
   validators2: 5.0.0
-  watcher: ^1.1.2
+  watcher: ^1.1.4
   web_socket_channel: ^3.0.0
   webkit_inspection_protocol: 1.2.1
   win32: ^5.3.0
   yaml: ^3.1.3
   yaml_edit: ^2.2.1
 dev_dependencies:
-  dcli: ^7.1.0
+  dcli: ^7.2.0
   lint_hard: ^6.2.1
   lints: ^6.0.0
   matcher: ^0.12.17


### PR DESCRIPTION
- Fix issue with `dcli_core: 7.2.0`.

- dcli: ^7.2.0
- dcli_core: ^7.2.0
- dcli_input: ^7.2.0
- dcli_terminal: ^7.2.0
- watcher: ^1.1.4